### PR TITLE
Add RequireValid option and add Valid() to geom types

### DIFF
--- a/circle.go
+++ b/circle.go
@@ -178,6 +178,11 @@ func (g *Circle) Empty() bool {
 	return false
 }
 
+// Valid ...
+func (g *Circle) Valid() bool {
+	return g.getObject().Valid()
+}
+
 // ForEach ...
 func (g *Circle) ForEach(iter func(geom Object) bool) bool {
 	return iter(g)

--- a/collection.go
+++ b/collection.go
@@ -64,6 +64,11 @@ func (g *collection) Empty() bool {
 	return g.pempty
 }
 
+// Valid ...
+func (g *collection) Valid() bool {
+	return g.Rect().Valid()
+}
+
 // Rect ...
 func (g *collection) Rect() geometry.Rect {
 	return g.prect

--- a/feature.go
+++ b/feature.go
@@ -45,6 +45,11 @@ func (g *Feature) Empty() bool {
 	return g.base.Empty()
 }
 
+// Valid ...
+func (g *Feature) Valid() bool {
+	return g.base.Valid()
+}
+
 // Rect ...
 func (g *Feature) Rect() geometry.Rect {
 	return g.base.Rect()

--- a/featurecollection_test.go
+++ b/featurecollection_test.go
@@ -18,3 +18,9 @@ func TestFeatureCollectionPoly(t *testing.T) {
 	expect(t, p.Intersects(PO(1, 2)))
 	expect(t, p.Contains(PO(1, 2)))
 }
+
+func TestFeatureCollectionValid(t *testing.T) {
+	json := `{"type":"FeatureCollection","features":[{"type":"Point","coordinates":[1,200]}]}`
+	expectJSON(t, json, nil)
+	expectJSONOpts(t, json, errCoordinatesInvalid, &ParseOptions{RequireValid: true})
+}

--- a/geometry/geometry.go
+++ b/geometry/geometry.go
@@ -8,6 +8,7 @@ package geometry
 type Geometry interface {
 	Rect() Rect
 	Empty() bool
+	Valid() bool
 	ContainsPoint(point Point) bool
 	IntersectsPoint(point Point) bool
 	ContainsRect(rect Rect) bool
@@ -20,3 +21,8 @@ type Geometry interface {
 
 // require conformance
 var _ = []Geometry{Point{}, Rect{}, &Line{}, &Poly{}}
+
+// WorldPolygon is the maximum bounds for any GeoPoint
+var WorldPolygon = NewPoly([]Point{
+	{-180, -90}, {-180, 90}, {180, 90}, {180, -90}, {-180, -90},
+}, nil, &IndexOptions{})

--- a/geometry/line.go
+++ b/geometry/line.go
@@ -9,6 +9,14 @@ type Line struct {
 	baseSeries
 }
 
+// Valid ...
+func (line *Line) Valid() bool {
+	if !WorldPolygon.ContainsLine(line) {
+		return false
+	}
+	return true
+}
+
 // NewLine creates a new Line
 func NewLine(points []Point, opts *IndexOptions) *Line {
 	line := new(Line)

--- a/geometry/point.go
+++ b/geometry/point.go
@@ -19,6 +19,14 @@ func (point Point) Empty() bool {
 	return false
 }
 
+// Valid ...
+func (point Point) Valid() bool {
+	if !WorldPolygon.ContainsPoint(point) {
+		return false
+	}
+	return true
+}
+
 // Rect ...
 func (point Point) Rect() Rect {
 	return Rect{point, point}

--- a/geometry/poly.go
+++ b/geometry/poly.go
@@ -39,6 +39,14 @@ func (poly *Poly) Empty() bool {
 	return poly.Exterior.Empty()
 }
 
+// Valid ...
+func (poly *Poly) Valid() bool {
+	if !WorldPolygon.ContainsPoly(poly) {
+		return false
+	}
+	return true
+}
+
 // Rect ...
 func (poly *Poly) Rect() Rect {
 	if poly == nil || poly.Exterior == nil {

--- a/geometry/poly_test.go
+++ b/geometry/poly_test.go
@@ -234,10 +234,21 @@ func Test369(t *testing.T) {
 		{-122.44, 37.7341129},
 		{-122.4408378, 37.7341129},
 	}, nil, DefaultIndexOptions)
+	d := NewPoly([]Point{
+		{-182.4408378, 37.7341129},
+		{-122.4408378, 37.733},
+		{-122.44, 37.733},
+		{-122.44, 37.7341129},
+		{-122.4408378, 137.7341129},
+	}, nil, DefaultIndexOptions)
 	expect(t, polyHoles.IntersectsPoly(a))
 	expect(t, !polyHoles.IntersectsPoly(b))
 	expect(t, !polyHoles.IntersectsPoly(c))
 	expect(t, a.IntersectsPoly(polyHoles))
 	expect(t, !b.IntersectsPoly(polyHoles))
 	expect(t, !c.IntersectsPoly(polyHoles))
+	expect(t, a.Valid())
+	expect(t, b.Valid())
+	expect(t, c.Valid())
+	expect(t, !d.Valid())
 }

--- a/geometry/rect.go
+++ b/geometry/rect.go
@@ -113,6 +113,14 @@ func (rect Rect) Empty() bool {
 	return false
 }
 
+// Valid ...
+func (rect Rect) Valid() bool {
+	if !WorldPolygon.ContainsRect(rect) {
+		return false
+	}
+	return false
+}
+
 // Rect ...
 func (rect Rect) Rect() Rect {
 	return rect

--- a/geometry/rect.go
+++ b/geometry/rect.go
@@ -118,7 +118,7 @@ func (rect Rect) Valid() bool {
 	if !WorldPolygon.ContainsRect(rect) {
 		return false
 	}
-	return false
+	return true
 }
 
 // Rect ...

--- a/geometry/rect_test.go
+++ b/geometry/rect_test.go
@@ -81,6 +81,10 @@ func TestRectEmpty(t *testing.T) {
 	expect(t, !R(0, 0, 10, 10).Empty())
 }
 
+func TestRectValid(t *testing.T) {
+	expect(t, R(0, 0, 10, 10).Valid())
+}
+
 func TestRectRect(t *testing.T) {
 	expect(t, R(0, 0, 10, 10).Rect() == R(0, 0, 10, 10))
 }

--- a/geometry/series.go
+++ b/geometry/series.go
@@ -136,6 +136,17 @@ func (series *baseSeries) Empty() bool {
 	return (series.closed && len(series.points) < 3) || len(series.points) < 2
 }
 
+// Valid ...
+func (series *baseSeries) Valid() bool {
+	valid := true
+	for _, point := range series.points {
+		if !point.Valid() {
+			valid = false
+		}
+	}
+	return valid
+}
+
 // Rect returns the series rectangle
 func (series *baseSeries) Rect() Rect {
 	return series.rect

--- a/geometrycollection_test.go
+++ b/geometrycollection_test.go
@@ -16,3 +16,9 @@ func TestGeometryCollectionPoly(t *testing.T) {
 	expect(t, p.Intersects(PO(1, 2)))
 	expect(t, p.Contains(PO(1, 2)))
 }
+
+func TestGeometryCollectionValid(t *testing.T) {
+	json := `{"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[1,200]}]}`
+	expectJSON(t, json, nil)
+	expectJSONOpts(t, json, errCoordinatesInvalid, &ParseOptions{RequireValid: true})
+}

--- a/linestring.go
+++ b/linestring.go
@@ -21,6 +21,11 @@ func (g *LineString) Empty() bool {
 	return g.base.Empty()
 }
 
+// Valid ...
+func (g *LineString) Valid() bool {
+	return g.base.Valid()
+}
+
 // Rect ...
 func (g *LineString) Rect() geometry.Rect {
 	return g.base.Rect()
@@ -144,6 +149,11 @@ func parseJSONLineString(keys *parseKeys, opts *ParseOptions) (Object, error) {
 	g.extra = ex
 	if err := parseBBoxAndExtras(&g.extra, keys, opts); err != nil {
 		return nil, err
+	}
+	if opts.RequireValid {
+		if !g.Valid() {
+			return nil, errDataInvalid
+		}
 	}
 	return &g, nil
 }

--- a/linestring_test.go
+++ b/linestring_test.go
@@ -18,6 +18,12 @@ func TestLineStringParse(t *testing.T) {
 	expectJSON(t, `{"type":"LineString","coordinates":[[3,4],[1,2]],"bbox":[1,2,3,4]}`, nil)
 }
 
+func TestLineStringParseValid(t *testing.T) {
+	json := `{"type":"LineString","coordinates":[[1,2],[-12,-190]]}`
+	expectJSON(t, json, nil)
+	expectJSONOpts(t, json, errDataInvalid, &ParseOptions{RequireValid: true})
+}
+
 func TestLineStringVarious(t *testing.T) {
 	var g = expectJSON(t, `{"type":"LineString","coordinates":[[3,4],[1,2]]}`, nil)
 	expect(t, string(g.AppendJSON(nil)) == `{"type":"LineString","coordinates":[[3,4],[1,2]]}`)
@@ -28,6 +34,16 @@ func TestLineStringVarious(t *testing.T) {
 	expect(t, !g.Empty())
 	expect(t, g.Rect() == R(1, 2, 3, 4))
 	expect(t, g.Center() == R(1, 2, 3, 4).Center())
+}
+
+func TestLineStringValid(t *testing.T) {
+	var g = expectJSON(t, `{"type":"LineString","coordinates":[[3,4],[1,2]]}`, nil)
+	expect(t, g.Valid())
+}
+
+func TestLineStringInvalid(t *testing.T) {
+	var g = expectJSON(t, `{"type":"LineString","coordinates":[[3,4],[1,2],[0, 190]]}`, nil)
+	expect(t, !g.Valid())
 }
 
 // func TestLineStringPoly(t *testing.T) {

--- a/multilinestring.go
+++ b/multilinestring.go
@@ -42,6 +42,17 @@ func (g *MultiLineString) String() string {
 	return string(g.AppendJSON(nil))
 }
 
+// Valid ...
+func (g *MultiLineString) Valid() bool {
+	valid := true
+	for _, p := range g.children {
+		if !p.Valid() {
+			valid = false
+		}
+	}
+	return valid
+}
+
 // JSON ...
 func (g *MultiLineString) JSON() string {
 	return string(g.AppendJSON(nil))
@@ -79,6 +90,11 @@ func parseJSONMultiLineString(
 	}
 	if err := parseBBoxAndExtras(&g.extra, keys, opts); err != nil {
 		return nil, err
+	}
+	if opts.RequireValid {
+		if !g.Valid() {
+			return nil, errCoordinatesInvalid
+		}
 	}
 	g.parseInitRectIndex(opts)
 	return &g, nil

--- a/multilinestring_test.go
+++ b/multilinestring_test.go
@@ -10,6 +10,15 @@ func TestMultiLineString(t *testing.T) {
 	expectJSON(t, `{"type":"MultiLineString","coordinates":[1,null]}`, errCoordinatesInvalid)
 }
 
+func TestMultiLineStringValid(t *testing.T) {
+	json := `{"type":"MultiLineString","coordinates":[
+		[[10,10],[120,190]],
+		[[50,50],[100,100]]
+	]}`
+	expectJSON(t, json, nil)
+	expectJSONOpts(t, json, errCoordinatesInvalid, &ParseOptions{RequireValid: true})
+}
+
 func TestMultiLineStringPoly(t *testing.T) {
 	p := expectJSON(t, `{"type":"MultiLineString","coordinates":[
 		[[10,10],[20,20]],

--- a/multipolygon.go
+++ b/multipolygon.go
@@ -41,6 +41,17 @@ func (g *MultiPolygon) String() string {
 	return string(g.AppendJSON(nil))
 }
 
+// Valid ...
+func (g *MultiPolygon) Valid() bool {
+	valid := true
+	for _, p := range g.children {
+		if !p.Valid() {
+			valid = false
+		}
+	}
+	return valid
+}
+
 // JSON ...
 func (g *MultiPolygon) JSON() string {
 	return string(g.AppendJSON(nil))
@@ -89,6 +100,11 @@ func parseJSONMultiPolygon(
 	}
 	if err := parseBBoxAndExtras(&g.extra, keys, opts); err != nil {
 		return nil, err
+	}
+	if opts.RequireValid {
+		if !g.Valid() {
+			return nil, errCoordinatesInvalid
+		}
 	}
 	g.parseInitRectIndex(opts)
 	return &g, nil

--- a/multipolygon_test.go
+++ b/multipolygon_test.go
@@ -25,6 +25,19 @@ func TestMultiPolygon(t *testing.T) {
 	expectJSON(t, `{"type":"MultiPolygon","coordinates":[1,null]}`, errCoordinatesInvalid)
 }
 
+func TestMultiPolygonParseValid(t *testing.T) {
+	json := `{"type":"MultiPolygon","coordinates":[
+		[
+			[[0,0],[10,0],[10,10],[0,10],[0,0]],
+			[[2,2],[8,2],[8,8],[2,8],[2,2]]
+		],[
+			[[0,0],[10,0],[10,10],[0,10],[0,0]],
+			[[2,2],[8,2],[8,8],[2,8],[2,2]]
+		]
+	]}`
+	expectJSONOpts(t, json, nil, &ParseOptions{RequireValid: true})
+}
+
 func TestMultiPolygonPoly(t *testing.T) {
 	p := expectJSON(t, `{"type":"MultiPolygon","coordinates":[
 		[

--- a/object.go
+++ b/object.go
@@ -30,6 +30,7 @@ var (
 // Object is a GeoJSON type
 type Object interface {
 	Empty() bool
+	Valid() bool
 	Rect() geometry.Rect
 	Center() geometry.Point
 	Contains(other Object) bool
@@ -87,6 +88,7 @@ type ParseOptions struct {
 	// IndexGeometryKind is the kind of index implementation.
 	// Default is QuadTreeCompressed
 	IndexGeometryKind geometry.IndexKind
+	RequireValid       bool
 }
 
 // DefaultParseOptions ...
@@ -94,6 +96,7 @@ var DefaultParseOptions = &ParseOptions{
 	IndexChildren:     64,
 	IndexGeometry:     64,
 	IndexGeometryKind: geometry.QuadTree,
+	RequireValid:       false,
 }
 
 // Parse a GeoJSON object

--- a/point.go
+++ b/point.go
@@ -34,6 +34,11 @@ func (g *Point) Empty() bool {
 	return g.base.Empty()
 }
 
+// Valid ...
+func (g *Point) Valid() bool {
+	return g.base.Valid()
+}
+
 // Rect ...
 func (g *Point) Rect() geometry.Rect {
 	return g.base.Rect()
@@ -150,6 +155,11 @@ func parseJSONPoint(keys *parseKeys, opts *ParseOptions) (Object, error) {
 	}
 	if err := parseBBoxAndExtras(&g.extra, keys, opts); err != nil {
 		return nil, err
+	}
+	if opts.RequireValid {
+		if !g.Valid() {
+			return nil, errCoordinatesInvalid
+		}
 	}
 	return &g, nil
 }

--- a/point_test.go
+++ b/point_test.go
@@ -13,6 +13,11 @@ func TestPointParse(t *testing.T) {
 	expectJSON(t, `{"type":"Point","coordinates":[1]}`, errCoordinatesInvalid)
 	expectJSON(t, `{"type":"Point","coordinates":[1,2,3],"bbox":[1,2,3,4]}`, `{"type":"Point","coordinates":[1,2,3],"bbox":[1,2,3,4]}`)
 }
+func TestPointParseValid(t *testing.T) {
+	json := `{"type":"Point","coordinates":[190,90]}`
+	expectJSON(t, json, nil)
+	expectJSONOpts(t, json, errCoordinatesInvalid, &ParseOptions{RequireValid: true})
+}
 
 func TestPointVarious(t *testing.T) {
 	var g Object = PO(10, 20)
@@ -20,6 +25,34 @@ func TestPointVarious(t *testing.T) {
 	expect(t, g.Rect() == R(10, 20, 10, 20))
 	expect(t, g.Center() == P(10, 20))
 	expect(t, !g.Empty())
+}
+
+func TestPointValid(t *testing.T) {
+	var g Object = PO(0, 20)
+	expect(t, g.Valid())
+
+	var g1 Object = PO(10, 20)
+	expect(t, g1.Valid())
+}
+
+func TestPointInvalidLargeX(t *testing.T) {
+	var g Object = PO(10, 91)
+	expect(t, !g.Valid())
+}
+
+func TestPointInvalidLargeY(t *testing.T) {
+	var g Object = PO(181, 20)
+	expect(t, !g.Valid())
+}
+
+func TestPointValidLargeX(t *testing.T) {
+	var g Object = PO(180, 20)
+	expect(t, g.Valid())
+}
+
+func TestPointValidLargeY(t *testing.T) {
+	var g Object = PO(180, 90)
+	expect(t, g.Valid())
 }
 
 // func TestPointPoly(t *testing.T) {

--- a/polygon.go
+++ b/polygon.go
@@ -21,6 +21,11 @@ func (g *Polygon) Empty() bool {
 	return g.base.Empty()
 }
 
+// Valid ...
+func (g *Polygon) Valid() bool {
+	return g.base.Valid()
+}
+
 // Rect ...
 func (g *Polygon) Rect() geometry.Rect {
 	return g.base.Rect()
@@ -162,6 +167,11 @@ func parseJSONPolygon(keys *parseKeys, opts *ParseOptions) (Object, error) {
 	g.extra = ex
 	if err := parseBBoxAndExtras(&g.extra, keys, opts); err != nil {
 		return nil, err
+	}
+	if opts.RequireValid {
+		if !g.Valid() {
+			return nil, errCoordinatesInvalid
+		}
 	}
 	return &g, nil
 }

--- a/polygon_test.go
+++ b/polygon_test.go
@@ -28,6 +28,14 @@ func TestPolygonParse(t *testing.T) {
 		`{"type":"Polygon","coordinates":[[[0,0,0],[10,0,4,5],[5,10],[0,0]]]}`,
 		`{"type":"Polygon","coordinates":[[[0,0,0],[10,0,4],[5,10,0],[0,0,0]]]}`)
 }
+func TestPolygonParseValid(t *testing.T) {
+	json := `{"type":"Polygon","coordinates":[
+		[[0,0],[190,0],[10,10],[0,10],[0,0]],
+		[[2,2],[8,2],[8,8],[2,8],[2,2]]
+	]}`
+	expectJSON(t, json, nil)
+	expectJSONOpts(t, json, errCoordinatesInvalid, &ParseOptions{RequireValid: true})
+}
 
 func TestPolygonVarious(t *testing.T) {
 	var g = expectJSON(t, `{"type":"Polygon","coordinates":[[[0,0],[10,0],[10,10],[0,10],[0,0]]]}`, nil)

--- a/rect.go
+++ b/rect.go
@@ -24,6 +24,11 @@ func (g *Rect) Empty() bool {
 	return g.base.Empty()
 }
 
+// Valid ...
+func (g *Rect) Valid() bool {
+	return g.base.Valid()
+}
+
 // Rect ...
 func (g *Rect) Rect() geometry.Rect {
 	return g.base

--- a/rect_test.go
+++ b/rect_test.go
@@ -41,3 +41,9 @@ func TestRect(t *testing.T) {
 	expect(t, (&Polygon{}).Distance(rect) != 0)
 
 }
+
+func TestRectValid(t *testing.T) {
+	json := `{"type":"Polygon","coordinates":[[[10,200],[30,200],[30,40],[10,40],[10,200]]]}`
+	expectJSON(t, json, nil)
+	expectJSONOpts(t, json, errCoordinatesInvalid, &ParseOptions{RequireValid: true})
+}


### PR DESCRIPTION
This adds config `ParseValid` `default: false` and func `Valid()` to the geometry types.
I added a `WorldPolygon` variable, not sure if you want to handle the max bounds differently. https://github.com/tidwall/geojson/compare/master...stevelacy:requirevalid?expand=1#diff-a62196bce3504b8d6a6c3a50de13fe73R26

I added test cases for all but the circle. I think this is how you would validate it? https://github.com/tidwall/geojson/compare/master...stevelacy:requirevalid?expand=1#diff-05508f93f36c3b0526f44f64f7f8a39aR183