### PR TITLE
Optimize point in ring

### DIFF
--- a/geometry/pip_bench_test.go
+++ b/geometry/pip_bench_test.go
@@ -103,3 +103,12 @@ func TestBigArizona(t *testing.T) {
 func TestBigTexas(t *testing.T) {
 	testBig(t, "tx", tx, P(-98.52539, 29.363027), P(-101.953125, 29.324720161))
 }
+
+func BenchmarkBigTexas_RTree(b *testing.B) {
+	opts := IndexOptions{Kind: RTree, MinPoints: 64}
+	ring := newRing(tx, &opts)
+	pointIn := P(-98.52539, 29.363027)
+	for i := 0; i < b.N; i++ {
+		ringContainsPoint(ring, pointIn, true)
+	}
+}


### PR DESCRIPTION
Since ring is an interface, the compiler cannot prove that the
closure created in ringContainsPoint is not needed after the
call to ring.Search completes. This causes the closure to be
allocated on the heap, reducing performance due to excessive
heap allocations. In tile38, this is on the hot path for WITHIN
commands on complex polygons.

Benchstat report for 10 runs of old an new code:

```
name               old time/op    new time/op    delta
BigTexas_RTree-12    1.09µs ± 3%    1.02µs ± 1%    -5.96%  (p=0.000 n=10+10)

name               old alloc/op   new alloc/op   delta
BigTexas_RTree-12     66.0B ± 0%      1.7B ±41%   -97.42%  (p=0.000 n=10+10)

name               old allocs/op  new allocs/op  delta
BigTexas_RTree-12      3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```