### PR TITLE
Fix wrong result in case of circle containing circle

### DIFF
--- a/circle.go
+++ b/circle.go
@@ -94,7 +94,7 @@ func (g *Circle) Contains(obj Object) bool {
 	case *SimplePoint:
 		return g.containsPoint(other.Center())
 	case *Circle:
-		return other.Distance(g) < (other.meters + g.meters)
+		return g.HaversineTo(other.center)+other.haversine <= g.haversine
 	case Collection:
 		for _, p := range other.Children() {
 			if !g.Contains(p) {
@@ -112,6 +112,8 @@ func (g *Circle) Contains(obj Object) bool {
 func (g *Circle) Intersects(obj Object) bool {
 	switch other := obj.(type) {
 	case *Point:
+		return g.containsPoint(other.Center())
+	case *SimplePoint:
 		return g.containsPoint(other.Center())
 	case *Circle:
 		return other.Distance(g) <= (other.meters + g.meters)

--- a/circle_test.go
+++ b/circle_test.go
@@ -64,7 +64,11 @@ func TestCircleContains(t *testing.T) {
 			},
 			[][]geometry.Point{})))
 
+	expect(t, g.Contains(g))
+	expect(t, g.Contains(NewCircle(g.Center(), g.meters/2, 64)))
+
 	// Does-not-contain
+	expect(t, !g.Contains(NewCircle(g.Center(), g.meters*3, 64)))
 	expect(t, !g.Contains(PO(-122.265, 37.826)))
 	expect(t, !g.Contains(
 		NewCircle(P(-122.265, 37.826), 100, 64)))
@@ -149,8 +153,12 @@ func TestCircleIntersects(t *testing.T) {
 				P(-122.44, 37.733),
 				P(-122.44, 37.7341129),
 			})})))
+	expect(t, g.Intersects(g))
+	expect(t, g.Intersects(NewCircle(g.Center(), g.meters/2, 64)))
+	expect(t, g.Intersects(NewCircle(g.Center(), g.meters*2, 64)))
 
 	// Does-not-intersect
+	expect(t, !g.Intersects(NewCircle(P(-122.5412, 37.8335), 10000, 64)))
 	expect(t, !g.Intersects(PO(-122.265, 37.826)))
 	expect(t, !g.Intersects(
 		NewCircle(P(-122.265, 37.826), 100, 64)))


### PR DESCRIPTION
I believe there was a bug in the case of calling Contains with two circles.

The test that was failing was:
```
expect(t, !g.Contains(NewCircle(g.Center(), g.meters*3, 64)))
```

Rest of tests cases added for completeness only.
Went with haversine comparison as it didn't have floating point error when comparing with the same circle:	`expect(t, g.Contains(g))`

Happy to make any changes (or just treat this PR as an illustration of the bug, feel free to close it :-)) 