### PR TITLE
Refactor floating point comparisons to use epsilon-based functions for improved precision

### DIFF
--- a/geometry/line.go
+++ b/geometry/line.go
@@ -89,14 +89,14 @@ func (line *Line) ContainsLine(other *Line) bool {
 		if lineSeg.ContainsSegment(otherSeg) {
 			continue
 		}
-		if otherSeg.A == lineSeg.A {
+		if PointEqual(otherSeg.A, lineSeg.A) {
 			// reverse it
 			if segIdx == 0 {
 				return false
 			}
 			segIdx--
 			i--
-		} else if otherSeg.A == lineSeg.B {
+		} else if PointEqual(otherSeg.A, lineSeg.B) {
 			// forward it
 			if segIdx == lineNumSegments-1 {
 				return false

--- a/geometry/point.go
+++ b/geometry/point.go
@@ -25,15 +25,15 @@ func (point Point) Rect() Rect {
 }
 
 func (point Point) ContainsPoint(other Point) bool {
-	return point == other
+	return PointEqual(point, other)
 }
 
 func (point Point) IntersectsPoint(other Point) bool {
-	return point == other
+	return PointEqual(point, other)
 }
 
 func (point Point) ContainsRect(rect Rect) bool {
-	return point.Rect() == rect
+	return RectEqual(point.Rect(), rect)
 }
 
 func (point Point) IntersectsRect(rect Rect) bool {
@@ -44,7 +44,7 @@ func (point Point) ContainsLine(line *Line) bool {
 	if line == nil {
 		return false
 	}
-	return !line.Empty() && line.Rect() == point.Rect()
+	return !line.Empty() && RectEqual(line.Rect(), point.Rect())
 }
 
 func (point Point) IntersectsLine(line *Line) bool {
@@ -58,7 +58,7 @@ func (point Point) ContainsPoly(poly *Poly) bool {
 	if poly == nil {
 		return false
 	}
-	return !poly.Empty() && poly.Rect() == point.Rect()
+	return !poly.Empty() && RectEqual(poly.Rect(), point.Rect())
 }
 
 func (point Point) IntersectsPoly(poly *Poly) bool {

--- a/geometry/precision.go
+++ b/geometry/precision.go
@@ -1,0 +1,76 @@
+// Copyright 2018 Joshua J Baker. All rights reserved.
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+package geometry
+
+import "math"
+
+// Epsilon for floating point precision across different platforms (ARM64, AMD64)
+//
+// We use 1e-8 instead of smaller values like 1e-10 for the following reasons:
+// 1. Geometric calculations involve multiple floating point operations that accumulate errors
+// 2. Cross-platform floating point differences between ARM64 and AMD64 can be in the 1e-9 range
+// 3. For geographic coordinates (GeoJSON's primary use case), 1e-8 degrees is approximately 1mm precision
+// 4. This epsilon provides a good balance between precision and robustness against computational noise
+const epsilon = 1e-8
+
+// FloatEqual checks if two float64 values are equal within epsilon tolerance
+func FloatEqual(a, b float64) bool {
+	return math.Abs(a-b) < epsilon
+}
+
+// FloatNotEqual checks if two float64 values are not equal within epsilon tolerance
+func FloatNotEqual(a, b float64) bool {
+	return !FloatEqual(a, b)
+}
+
+// FloatLess checks if a is less than b with epsilon tolerance
+func FloatLess(a, b float64) bool {
+	return (b - a) > epsilon
+}
+
+// FloatLessOrEqual checks if a is less than or equal to b with epsilon tolerance
+func FloatLessOrEqual(a, b float64) bool {
+	return FloatLess(a, b) || FloatEqual(a, b)
+}
+
+// FloatGreater checks if a is greater than b with epsilon tolerance
+func FloatGreater(a, b float64) bool {
+	return (a - b) > epsilon
+}
+
+// FloatGreaterOrEqual checks if a is greater than or equal to b with epsilon tolerance
+func FloatGreaterOrEqual(a, b float64) bool {
+	return FloatGreater(a, b) || FloatEqual(a, b)
+}
+
+// FloatZero checks if a float64 value is effectively zero
+func FloatZero(x float64) bool {
+	return math.Abs(x) < epsilon
+}
+
+// FloatNonZero checks if a float64 value is effectively non-zero
+func FloatNonZero(x float64) bool {
+	return !FloatZero(x)
+}
+
+// PointEqual checks if two points are equal within epsilon tolerance
+func PointEqual(a, b Point) bool {
+	return FloatEqual(a.X, b.X) && FloatEqual(a.Y, b.Y)
+}
+
+// PointNotEqual checks if two points are not equal within epsilon tolerance
+func PointNotEqual(a, b Point) bool {
+	return !PointEqual(a, b)
+}
+
+// RectEqual checks if two rectangles are equal within epsilon tolerance
+func RectEqual(a, b Rect) bool {
+	return PointEqual(a.Min, b.Min) && PointEqual(a.Max, b.Max)
+}
+
+// RectNotEqual checks if two rectangles are not equal within epsilon tolerance
+func RectNotEqual(a, b Rect) bool {
+	return !RectEqual(a, b)
+}

--- a/geometry/precision_test.go
+++ b/geometry/precision_test.go
@@ -1,0 +1,171 @@
+package geometry
+
+import (
+	"testing"
+)
+
+func TestFloatComparisons(t *testing.T) {
+	// Test basic float comparisons
+	a := 1.0
+	b := 1.0 + epsilon/2 // Should be considered equal
+	c := 1.0 + epsilon*2 // Should be considered different
+
+	if !FloatEqual(a, b) {
+		t.Errorf("Expected %f and %f to be equal", a, b)
+	}
+
+	if FloatEqual(a, c) {
+		t.Errorf("Expected %f and %f to not be equal", a, c)
+	}
+
+	if !FloatLess(a, c) {
+		t.Errorf("Expected %f to be less than %f", a, c)
+	}
+
+	if !FloatGreater(c, a) {
+		t.Errorf("Expected %f to be greater than %f", c, a)
+	}
+}
+
+func TestPointComparisons(t *testing.T) {
+	// Test point comparisons
+	p1 := Point{X: 1.0, Y: 2.0}
+	p2 := Point{X: 1.0 + epsilon/2, Y: 2.0 + epsilon/2} // Should be equal
+	p3 := Point{X: 1.0 + epsilon*2, Y: 2.0}             // Should be different
+
+	if !PointEqual(p1, p2) {
+		t.Errorf("Expected points %v and %v to be equal", p1, p2)
+	}
+
+	if PointEqual(p1, p3) {
+		t.Errorf("Expected points %v and %v to not be equal", p1, p3)
+	}
+}
+
+func TestSegmentIntersection(t *testing.T) {
+	// Test segment intersection with floating point precision
+	seg1 := Segment{A: Point{X: 0, Y: 0}, B: Point{X: 1, Y: 1}}
+	seg2 := Segment{A: Point{X: 0, Y: 1}, B: Point{X: 1, Y: 0}}
+
+	// These segments should intersect at (0.5, 0.5)
+	if !seg1.IntersectsSegment(seg2) {
+		t.Error("Expected segments to intersect")
+	}
+
+	// Test with very close but not identical points
+	seg3 := Segment{
+		A: Point{X: 0 + epsilon/2, Y: 0 + epsilon/2},
+		B: Point{X: 1 + epsilon/2, Y: 1 + epsilon/2},
+	}
+	seg4 := Segment{
+		A: Point{X: 0 + epsilon/2, Y: 1 + epsilon/2},
+		B: Point{X: 1 + epsilon/2, Y: 0 + epsilon/2},
+	}
+
+	if !seg3.IntersectsSegment(seg4) {
+		t.Error("Expected segments with epsilon differences to still intersect")
+	}
+}
+
+func TestIntersectsSegmentPrecision(t *testing.T) {
+	// Test boundary conditions with epsilon precision
+
+	// Test case 1: Segments that barely intersect
+	seg1 := Segment{A: Point{X: 0, Y: 0}, B: Point{X: 1, Y: 0}}
+	seg2 := Segment{A: Point{X: 0.5, Y: -epsilon / 2}, B: Point{X: 0.5, Y: epsilon / 2}}
+
+	if !seg1.IntersectsSegment(seg2) {
+		t.Error("Expected segments with epsilon-level intersection to intersect")
+	}
+
+	// Test case 2: Segments that barely don't intersect
+	seg3 := Segment{A: Point{X: 0, Y: 0}, B: Point{X: 1, Y: 0}}
+	seg4 := Segment{A: Point{X: 0.5, Y: epsilon * 2}, B: Point{X: 0.5, Y: epsilon * 3}}
+
+	if seg3.IntersectsSegment(seg4) {
+		t.Error("Expected segments with clear separation to not intersect")
+	}
+
+	// Test case 3: Collinear segments with epsilon differences
+	seg5 := Segment{A: Point{X: 0, Y: 0}, B: Point{X: 1, Y: 1}}
+	seg6 := Segment{A: Point{X: 0.5 + epsilon/2, Y: 0.5 + epsilon/2}, B: Point{X: 1.5 + epsilon/2, Y: 1.5 + epsilon/2}}
+
+	if !seg5.IntersectsSegment(seg6) {
+		t.Error("Expected overlapping collinear segments with epsilon differences to intersect")
+	}
+
+	// Test case 4: Parallel segments
+	seg7 := Segment{A: Point{X: 0, Y: 0}, B: Point{X: 1, Y: 0}}
+	seg8 := Segment{A: Point{X: 0, Y: epsilon * 2}, B: Point{X: 1, Y: epsilon * 2}}
+
+	if seg7.IntersectsSegment(seg8) {
+		t.Error("Expected parallel segments to not intersect")
+	}
+}
+
+func TestRaycastPrecision(t *testing.T) {
+	// Test raycast with floating point precision
+	seg := Segment{A: Point{X: 0, Y: 0}, B: Point{X: 1, Y: 0}}
+
+	// Point exactly on the segment
+	p1 := Point{X: 0.5, Y: 0}
+	result1 := seg.Raycast(p1)
+	if !result1.On {
+		t.Error("Expected point to be on segment")
+	}
+
+	// Point very close to the segment (within epsilon)
+	p2 := Point{X: 0.5, Y: epsilon / 2}
+	result2 := seg.Raycast(p2)
+	_ = result2 // This should be considered as close enough depending on implementation
+
+	// Point clearly off the segment
+	p3 := Point{X: 0.5, Y: epsilon * 10}
+	result3 := seg.Raycast(p3)
+	if result3.On {
+		t.Error("Expected point to not be on segment")
+	}
+}
+
+func TestEpsilonChoiceValidation(t *testing.T) {
+	// Test to validate the choice of epsilon = 1e-8 vs 1e-10
+
+	// Simulate typical geometric computation errors
+	baseValue := 1.0
+
+	// Error from a typical floating point multiplication chain
+	// e.g., result of several coordinate transformations
+	computedValue1 := baseValue + 1e-9 // Small computational error
+	computedValue2 := baseValue + 5e-9 // Larger computational error
+	computedValue3 := baseValue + 1e-7 // Clear difference
+
+	// With epsilon = 1e-8, these should be the expected results:
+
+	// Very small error should be considered equal
+	if !FloatEqual(baseValue, computedValue1) {
+		t.Errorf("With epsilon=1e-8, expected %e and %e to be equal (computational noise)", baseValue, computedValue1)
+	}
+
+	// Moderate error should still be considered equal (accumulated precision loss)
+	if !FloatEqual(baseValue, computedValue2) {
+		t.Errorf("With epsilon=1e-8, expected %e and %e to be equal (accumulated error)", baseValue, computedValue2)
+	}
+
+	// Large error should be considered different
+	if FloatEqual(baseValue, computedValue3) {
+		t.Errorf("With epsilon=1e-8, expected %e and %e to be different", baseValue, computedValue3)
+	}
+
+	// Test with coordinate-scale values (typical for geographic data)
+	lng1 := -122.4194155 // San Francisco longitude
+	lng2 := lng1 + 1e-9  // Tiny GPS precision difference
+	lng3 := lng1 + 1e-7  // Meaningful geographic difference (~1cm at equator)
+
+	if !FloatEqual(lng1, lng2) {
+		t.Errorf("GPS coordinates with noise should be considered equal: %f vs %f", lng1, lng2)
+	}
+
+	if FloatEqual(lng1, lng3) {
+		t.Errorf("GPS coordinates with meaningful difference should not be equal: %f vs %f", lng1, lng3)
+	}
+}

--- a/geometry/raycast.go
+++ b/geometry/raycast.go
@@ -20,79 +20,94 @@ func (seg Segment) Raycast(point Point) RaycastResult {
 	}
 
 	// test if point is in on the segment
-	if a.Y == b.Y {
-		if a.X == b.X {
-			if p == a {
+	if FloatEqual(a.Y, b.Y) {
+		if FloatEqual(a.X, b.X) {
+			if PointEqual(p, a) {
 				return RaycastResult{false, true}
 			}
 			return RaycastResult{false, false}
 		}
-		if p.Y == b.Y {
+		if FloatEqual(p.Y, b.Y) {
 			// horizontal segment
 			// check if the point in on the line
-			if a.X < b.X {
-				if p.X >= a.X && p.X <= b.X {
+			if FloatLess(a.X, b.X) {
+				if FloatGreaterOrEqual(p.X, a.X) && FloatLessOrEqual(p.X, b.X) {
 					return RaycastResult{false, true}
 				}
 			} else {
-				if p.X >= b.X && p.X <= a.X {
+				if FloatGreaterOrEqual(p.X, b.X) && FloatLessOrEqual(p.X, a.X) {
 					return RaycastResult{false, true}
 				}
 			}
 		}
 	}
-	if a.X == b.X && p.X == b.X {
+	if FloatEqual(a.X, b.X) && FloatEqual(p.X, b.X) {
 		// vertical segment
 		// check if the point in on the line
-		if a.Y < b.Y {
-			if p.Y >= a.Y && p.Y <= b.Y {
+		if FloatLess(a.Y, b.Y) {
+			if FloatGreaterOrEqual(p.Y, a.Y) && FloatLessOrEqual(p.Y, b.Y) {
 				return RaycastResult{false, true}
 			}
 		} else {
-			if p.Y >= b.Y && p.Y <= a.Y {
+			if FloatGreaterOrEqual(p.Y, b.Y) && FloatLessOrEqual(p.Y, a.Y) {
 				return RaycastResult{false, true}
 			}
 		}
 	}
-	if (p.X-a.X)/(b.X-a.X) == (p.Y-a.Y)/(b.Y-a.Y) {
-		return RaycastResult{false, true}
+	// Use epsilon comparison for slope equality instead of direct division comparison
+	if FloatNonZero(b.X-a.X) && FloatNonZero(b.Y-a.Y) {
+		slope1 := (p.X - a.X) / (b.X - a.X)
+		slope2 := (p.Y - a.Y) / (b.Y - a.Y)
+		if FloatEqual(slope1, slope2) {
+			return RaycastResult{false, true}
+		}
 	}
 
 	// do the actual raycast here.
-	for p.Y == a.Y || p.Y == b.Y {
+	for FloatEqual(p.Y, a.Y) || FloatEqual(p.Y, b.Y) {
 		p.Y = math.Nextafter(p.Y, math.Inf(1))
 	}
-	if a.Y < b.Y {
-		if p.Y < a.Y || p.Y > b.Y {
+	if FloatLess(a.Y, b.Y) {
+		if FloatLess(p.Y, a.Y) || FloatGreater(p.Y, b.Y) {
 			return RaycastResult{false, false}
 		}
 	} else {
-		if p.Y < b.Y || p.Y > a.Y {
+		if FloatLess(p.Y, b.Y) || FloatGreater(p.Y, a.Y) {
 			return RaycastResult{false, false}
 		}
 	}
-	if a.X > b.X {
-		if p.X >= a.X {
+	if FloatGreater(a.X, b.X) {
+		if FloatGreaterOrEqual(p.X, a.X) {
 			return RaycastResult{false, false}
 		}
-		if p.X <= b.X {
+		if FloatLessOrEqual(p.X, b.X) {
 			return RaycastResult{true, false}
 		}
 	} else {
-		if p.X >= b.X {
+		if FloatGreaterOrEqual(p.X, b.X) {
 			return RaycastResult{false, false}
 		}
-		if p.X <= a.X {
+		if FloatLessOrEqual(p.X, a.X) {
 			return RaycastResult{true, false}
 		}
 	}
-	if a.Y < b.Y {
-		if (p.Y-a.Y)/(p.X-a.X) >= (b.Y-a.Y)/(b.X-a.X) {
-			return RaycastResult{true, false}
+	if FloatLess(a.Y, b.Y) {
+		// Use epsilon-safe division comparison
+		if FloatNonZero(p.X-a.X) && FloatNonZero(b.X-a.X) {
+			slope1 := (p.Y - a.Y) / (p.X - a.X)
+			slope2 := (b.Y - a.Y) / (b.X - a.X)
+			if FloatGreaterOrEqual(slope1, slope2) {
+				return RaycastResult{true, false}
+			}
 		}
 	} else {
-		if (p.Y-b.Y)/(p.X-b.X) >= (a.Y-b.Y)/(a.X-b.X) {
-			return RaycastResult{true, false}
+		// Use epsilon-safe division comparison
+		if FloatNonZero(p.X-b.X) && FloatNonZero(a.X-b.X) {
+			slope1 := (p.Y - b.Y) / (p.X - b.X)
+			slope2 := (a.Y - b.Y) / (a.X - b.X)
+			if FloatGreaterOrEqual(slope1, slope2) {
+				return RaycastResult{true, false}
+			}
 		}
 	}
 	return RaycastResult{false, false}

--- a/geometry/ring.go
+++ b/geometry/ring.go
@@ -107,7 +107,7 @@ func ringContainsSegment(ring Ring, seg Segment, allowOnEdge bool) bool {
 		// seg A is not inside ring
 		return false
 	}
-	if seg.B == seg.A {
+	if PointEqual(seg.B, seg.A) {
 		return true
 	}
 	resB := ringContainsPoint(ring, seg.B, allowOnEdge)
@@ -144,10 +144,10 @@ func ringContainsSegment(ring Ring, seg Segment, allowOnEdge bool) bool {
 
 				rSegA := ring.SegmentAt(resA.idx)
 				rSegB := ring.SegmentAt(resB.idx)
-				if rSegA.A == seg.A || rSegA.B == seg.A ||
-					rSegB.A == seg.A || rSegB.B == seg.A ||
-					rSegA.A == seg.B || rSegA.B == seg.B ||
-					rSegB.A == seg.B || rSegB.B == seg.B {
+				if PointEqual(rSegA.A, seg.A) || PointEqual(rSegA.B, seg.A) ||
+					PointEqual(rSegB.A, seg.A) || PointEqual(rSegB.B, seg.A) ||
+					PointEqual(rSegA.A, seg.B) || PointEqual(rSegA.B, seg.B) ||
+					PointEqual(rSegB.A, seg.B) || PointEqual(rSegB.B, seg.B) {
 					return true
 				}
 
@@ -267,13 +267,13 @@ func ringIntersectsSegment(ring Ring, seg Segment, allowOnEdge bool) bool {
 				// must be taken.
 				if !(seg.CollinearPoint(seg2.A) && seg.CollinearPoint(seg2.B)) {
 					if !segAOn {
-						if seg.A == seg2.A || seg.A == seg2.B {
+						if PointEqual(seg.A, seg2.A) || PointEqual(seg.A, seg2.B) {
 							segAOn = true
 							return true
 						}
 					}
 					if !segBOn {
-						if seg.B == seg2.A || seg.B == seg2.B {
+						if PointEqual(seg.B, seg2.A) || PointEqual(seg.B, seg2.B) {
 							segBOn = true
 							return true
 						}

--- a/geometry/segment.go
+++ b/geometry/segment.go
@@ -5,7 +5,7 @@
 package geometry
 
 func eqZero(x float64) bool {
-	return !(x < 0 || x > 0)
+	return FloatZero(x)
 }
 
 // Segment is a two point line
@@ -54,50 +54,50 @@ func (seg Segment) ContainsPoint(point Point) bool {
 func (seg Segment) IntersectsSegment(other Segment) bool {
 	a, b, c, d := seg.A, seg.B, other.A, other.B
 	// do the bounding boxes intersect?
-	if a.Y > b.Y {
-		if c.Y > d.Y {
-			if b.Y > c.Y || a.Y < d.Y {
+	if FloatGreater(a.Y, b.Y) {
+		if FloatGreater(c.Y, d.Y) {
+			if FloatGreater(b.Y, c.Y) || FloatLess(a.Y, d.Y) {
 				return false
 			}
 		} else {
-			if b.Y > d.Y || a.Y < c.Y {
+			if FloatGreater(b.Y, d.Y) || FloatLess(a.Y, c.Y) {
 				return false
 			}
 		}
 	} else {
-		if c.Y > d.Y {
-			if a.Y > c.Y || b.Y < d.Y {
+		if FloatGreater(c.Y, d.Y) {
+			if FloatGreater(a.Y, c.Y) || FloatLess(b.Y, d.Y) {
 				return false
 			}
 		} else {
-			if a.Y > d.Y || b.Y < c.Y {
+			if FloatGreater(a.Y, d.Y) || FloatLess(b.Y, c.Y) {
 				return false
 			}
 		}
 	}
-	if a.X > b.X {
-		if c.X > d.X {
-			if b.X > c.X || a.X < d.X {
+	if FloatGreater(a.X, b.X) {
+		if FloatGreater(c.X, d.X) {
+			if FloatGreater(b.X, c.X) || FloatLess(a.X, d.X) {
 				return false
 			}
 		} else {
-			if b.X > d.X || a.X < c.X {
+			if FloatGreater(b.X, d.X) || FloatLess(a.X, c.X) {
 				return false
 			}
 		}
 	} else {
-		if c.X > d.X {
-			if a.X > c.X || b.X < d.X {
+		if FloatGreater(c.X, d.X) {
+			if FloatGreater(a.X, c.X) || FloatLess(b.X, d.X) {
 				return false
 			}
 		} else {
-			if a.X > d.X || b.X < c.X {
+			if FloatGreater(a.X, d.X) || FloatLess(b.X, c.X) {
 				return false
 			}
 		}
 	}
-	if seg.A == other.A || seg.A == other.B ||
-		seg.B == other.A || seg.B == other.B {
+	if PointEqual(seg.A, other.A) || PointEqual(seg.A, other.B) ||
+		PointEqual(seg.B, other.A) || PointEqual(seg.B, other.B) {
 		return true
 	}
 
@@ -107,8 +107,8 @@ func (seg Segment) IntersectsSegment(other Segment) bool {
 	cmpxr := cmpx*ry - cmpy*rx
 	if eqZero(cmpxr) {
 		// Lines are collinear, and so intersect if they have any overlap
-		if !(((c.X-a.X <= 0) != (c.X-b.X <= 0)) ||
-			((c.Y-a.Y <= 0) != (c.Y-b.Y <= 0))) {
+		if !(((FloatLessOrEqual(c.X-a.X, 0)) != (FloatLessOrEqual(c.X-b.X, 0))) ||
+			((FloatLessOrEqual(c.Y-a.Y, 0)) != (FloatLessOrEqual(c.Y-b.Y, 0)))) {
 			return seg.Raycast(other.A).On || seg.Raycast(other.B).On
 			//return false
 		}
@@ -123,11 +123,10 @@ func (seg Segment) IntersectsSegment(other Segment) bool {
 	rxsr := 1 / rxs
 	t := cmpxs * rxsr
 	u := cmpxr * rxsr
-	if !((t >= 0) && (t <= 1) && (u >= 0) && (u <= 1)) {
+	if !((FloatGreaterOrEqual(t, 0)) && (FloatLessOrEqual(t, 1)) && (FloatGreaterOrEqual(u, 0)) && (FloatLessOrEqual(u, 1))) {
 		return false
 	}
 	return true
-
 }
 
 // ContainsSegment returns true if segment contains other segment

--- a/geometry/series.go
+++ b/geometry/series.go
@@ -273,22 +273,22 @@ func processPoints(points []Point, closed bool) (
 
 		zCrossProduct := (b.X-a.X)*(c.Y-b.Y) - (b.Y-a.Y)*(c.X-b.X)
 		if dir == 0 {
-			if zCrossProduct < 0 {
+			if FloatLess(zCrossProduct, 0) {
 				dir = -1
-			} else if zCrossProduct > 0 {
+			} else if FloatGreater(zCrossProduct, 0) {
 				dir = 1
 			}
-		} else if zCrossProduct < 0 {
+		} else if FloatLess(zCrossProduct, 0) {
 			if dir == 1 {
 				concave = true
 			}
-		} else if zCrossProduct > 0 {
+		} else if FloatGreater(zCrossProduct, 0) {
 			if dir == -1 {
 				concave = true
 			}
 		}
 	}
-	return !concave, rect, cwc > 0
+	return !concave, rect, FloatGreater(cwc, 0)
 }
 
 func (series *baseSeries) clearIndex() {


### PR DESCRIPTION
In the amd64 and arm64 platform architectures, there may be inconsistencies in floating-point comparison calculations. As shown in the following figure, it is the debugging result of the IntersectsSegment function. I took the same input and output different results under different architectures.
I used the epsilon method to solve this problem.

arm64:
<img width="1392" height="732" alt="480b837ba206238eedded83c425da7cb" src="https://github.com/user-attachments/assets/07f42a1f-3807-4f1e-8c06-3aaf8d4cc69d" />

amd64:
<img width="1353" height="714" alt="f5701788553fb1df35e7081adc72e337" src="https://github.com/user-attachments/assets/ac4ed10a-a832-4e55-9b9a-3c8b3ba83d87" />

