### PR TITLE
Add FixWinding and RequireWinding parse options (RFC 7946 §3.1.6)

### DIFF
--- a/multipolygon.go
+++ b/multipolygon.go
@@ -83,6 +83,9 @@ func parseJSONMultiPolygon(
 				return false
 			}
 		}
+		if err = applyRFC7946Winding(coords, ex, opts); err != nil {
+			return false
+		}
 		exterior := coords[0]
 		var holes [][]geometry.Point
 		if len(coords) > 1 {

--- a/object.go
+++ b/object.go
@@ -103,6 +103,16 @@ type ParseOptions struct {
 	// exactly 5 points with the first point being the min x/y and the
 	// following point winding counter clockwise creating a closed rectangle.
 	AllowRects bool
+	// FixWinding rewrites Polygon and MultiPolygon rings during parse so they
+	// follow RFC 7946 §3.1.6: exterior rings counterclockwise, holes clockwise.
+	// Rings already compliant (or degenerate with zero signed area) are left
+	// untouched. Cannot be combined with RequireWinding.
+	FixWinding bool
+	// RequireWinding causes parse to fail when a Polygon or MultiPolygon ring
+	// violates RFC 7946 §3.1.6 winding (exterior CCW, holes CW). Degenerate
+	// rings with zero signed area are not rejected. Cannot be combined with
+	// FixWinding.
+	RequireWinding bool
 }
 
 var DefaultParseOptions = &ParseOptions{
@@ -113,6 +123,8 @@ var DefaultParseOptions = &ParseOptions{
 	AllowSimplePoints: false,
 	DisableCircleType: false,
 	AllowRects:        false,
+	FixWinding:        false,
+	RequireWinding:    false,
 }
 
 // Parse a GeoJSON object

--- a/object.go
+++ b/object.go
@@ -106,12 +106,28 @@ type ParseOptions struct {
 	// FixWinding rewrites Polygon and MultiPolygon rings during parse so they
 	// follow RFC 7946 §3.1.6: exterior rings counterclockwise, holes clockwise.
 	// Rings already compliant (or degenerate with zero signed area) are left
-	// untouched. Cannot be combined with RequireWinding.
+	// untouched. When FixWinding runs before the AllowRects fast path, a
+	// clockwise-wound rectangle will be flipped and then recognized as a Rect;
+	// the same input with FixWinding disabled parses as a CW Polygon.
+	//
+	// Ring orientation is computed with the planar shoelace formula, which
+	// does not account for the antimeridian — polygons whose coordinates
+	// straddle ±180° longitude may be misclassified.
+	//
+	// If both FixWinding and RequireWinding are set, RequireWinding takes
+	// precedence (non-compliant rings produce an error and are not rewritten).
 	FixWinding bool
-	// RequireWinding causes parse to fail when a Polygon or MultiPolygon ring
-	// violates RFC 7946 §3.1.6 winding (exterior CCW, holes CW). Degenerate
-	// rings with zero signed area are not rejected. Cannot be combined with
-	// FixWinding.
+	// RequireWinding causes parse to fail with errCoordinatesInvalid when any
+	// Polygon or MultiPolygon ring violates RFC 7946 §3.1.6 winding (exterior
+	// CCW, holes CW). Degenerate rings with zero signed area are not rejected.
+	//
+	// Note that RFC 7946 §3.1.6 uses "SHOULD" and says parsers "SHOULD NOT
+	// reject Polygons that do not follow the right-hand rule." Enabling this
+	// option is therefore stricter than the RFC recommends and is intended
+	// for validation pipelines that want explicit winding enforcement.
+	//
+	// Orientation is computed with the planar shoelace formula; antimeridian
+	// polygons may be misclassified. See FixWinding for details.
 	RequireWinding bool
 }
 

--- a/polygon.go
+++ b/polygon.go
@@ -142,6 +142,9 @@ func parseJSONPolygon(keys *parseKeys, opts *ParseOptions) (Object, error) {
 			return nil, errCoordinatesInvalid // must be a linear ring
 		}
 	}
+	if err := applyRFC7946Winding(coords, extra, opts); err != nil {
+		return nil, err
+	}
 	exterior := coords[0]
 	var holes [][]geometry.Point
 	if len(coords) > 1 {

--- a/winding.go
+++ b/winding.go
@@ -6,6 +6,8 @@ import "github.com/tidwall/geojson/geometry"
 // degenerate rings (zero signed area or fewer than three distinct points).
 // GeoJSON uses geographic coordinates with latitude (Y) increasing northward,
 // so the standard Cartesian shoelace sign convention matches RFC 7946 §3.1.6.
+// This is a planar computation: rings that cross the antimeridian (±180°
+// longitude) may be classified with the wrong sign.
 func ringOrientation(pts []geometry.Point) int {
 	n := len(pts)
 	if n < 3 {
@@ -40,6 +42,10 @@ func reverseExtraRange(ex *extra, pointOffset, nPoints int) {
 	}
 	dims := int(ex.dims)
 	base := pointOffset * dims
+	end := base + nPoints*dims
+	if base < 0 || end > len(ex.values) {
+		return
+	}
 	for i, j := 0, nPoints-1; i < j; i, j = i+1, j-1 {
 		for k := 0; k < dims; k++ {
 			ex.values[base+i*dims+k], ex.values[base+j*dims+k] =

--- a/winding.go
+++ b/winding.go
@@ -1,0 +1,79 @@
+package geojson
+
+import "github.com/tidwall/geojson/geometry"
+
+// ringOrientation returns +1 for counterclockwise, -1 for clockwise, and 0 for
+// degenerate rings (zero signed area or fewer than three distinct points).
+// GeoJSON uses geographic coordinates with latitude (Y) increasing northward,
+// so the standard Cartesian shoelace sign convention matches RFC 7946 §3.1.6.
+func ringOrientation(pts []geometry.Point) int {
+	n := len(pts)
+	if n < 3 {
+		return 0
+	}
+	var area float64
+	for i := 0; i < n; i++ {
+		j := (i + 1) % n
+		area += pts[i].X*pts[j].Y - pts[j].X*pts[i].Y
+	}
+	if area > 0 {
+		return 1
+	}
+	if area < 0 {
+		return -1
+	}
+	return 0
+}
+
+func reverseRing(pts []geometry.Point) {
+	for i, j := 0, len(pts)-1; i < j; i, j = i+1, j-1 {
+		pts[i], pts[j] = pts[j], pts[i]
+	}
+}
+
+// reverseExtraRange reverses the per-point extra values for one ring. The
+// ring occupies len(ring) consecutive points starting at pointOffset inside
+// ex.values, with each point holding dims floats.
+func reverseExtraRange(ex *extra, pointOffset, nPoints int) {
+	if ex == nil || ex.dims == 0 || nPoints < 2 {
+		return
+	}
+	dims := int(ex.dims)
+	base := pointOffset * dims
+	for i, j := 0, nPoints-1; i < j; i, j = i+1, j-1 {
+		for k := 0; k < dims; k++ {
+			ex.values[base+i*dims+k], ex.values[base+j*dims+k] =
+				ex.values[base+j*dims+k], ex.values[base+i*dims+k]
+		}
+	}
+}
+
+// applyRFC7946Winding enforces RFC 7946 §3.1.6 ring winding on a single
+// polygon's coords (exterior at index 0, holes after). It honours the
+// FixWinding and RequireWinding parse options.
+func applyRFC7946Winding(
+	coords [][]geometry.Point, ex *extra, opts *ParseOptions,
+) error {
+	if opts == nil || (!opts.FixWinding && !opts.RequireWinding) {
+		return nil
+	}
+	offset := 0
+	for i, ring := range coords {
+		orient := ringOrientation(ring)
+		wantCCW := i == 0
+		if orient != 0 {
+			compliant := (wantCCW && orient == 1) || (!wantCCW && orient == -1)
+			if !compliant {
+				if opts.RequireWinding {
+					return errCoordinatesInvalid
+				}
+				if opts.FixWinding {
+					reverseRing(ring)
+					reverseExtraRange(ex, offset, len(ring))
+				}
+			}
+		}
+		offset += len(ring)
+	}
+	return nil
+}

--- a/winding_test.go
+++ b/winding_test.go
@@ -82,6 +82,37 @@ func TestMultiPolygonRequireWindingRejects(t *testing.T) {
 	expectJSONOpts(t, in, errCoordinatesInvalid, &ParseOptions{RequireWinding: true})
 }
 
+// Degenerate rings (zero signed area) carry no orientation and must be
+// accepted by RequireWinding rather than rejected.
+func TestPolygonRequireWindingAcceptsDegenerate(t *testing.T) {
+	in := `{"type":"Polygon","coordinates":[[[0,0],[5,5],[10,10],[0,0]]]}`
+	expectJSONOpts(t, in, in, &ParseOptions{RequireWinding: true})
+}
+
+// Polygon with a hole plus z-coords: exercises pointOffset advancing across
+// the exterior before reversing the hole's slice of extra.values.
+func TestPolygonFixWindingHoleWithZ(t *testing.T) {
+	in := `{"type":"Polygon","coordinates":[` +
+		`[[0,0,1],[10,0,2],[10,10,3],[0,10,4],[0,0,1]],` +
+		`[[2,2,5],[8,2,6],[8,8,7],[2,8,8],[2,2,5]]]}`
+	want := `{"type":"Polygon","coordinates":[` +
+		`[[0,0,1],[10,0,2],[10,10,3],[0,10,4],[0,0,1]],` +
+		`[[2,2,5],[2,8,8],[8,8,7],[8,2,6],[2,2,5]]]}`
+	expectJSONOpts(t, in, want, &ParseOptions{FixWinding: true})
+}
+
+// MultiPolygon where each sub-polygon carries its own z-values: confirms the
+// per-polygon offset resets between children (each child has its own extra).
+func TestMultiPolygonFixWindingPerChildZ(t *testing.T) {
+	in := `{"type":"MultiPolygon","coordinates":[` +
+		`[[[0,0,1],[0,10,2],[10,10,3],[10,0,4],[0,0,1]]],` +
+		`[[[20,0,5],[30,0,6],[30,10,7],[20,10,8],[20,0,5]]]]}`
+	want := `{"type":"MultiPolygon","coordinates":[` +
+		`[[[0,0,1],[10,0,4],[10,10,3],[0,10,2],[0,0,1]]],` +
+		`[[[20,0,5],[30,0,6],[30,10,7],[20,10,8],[20,0,5]]]]}`
+	expectJSONOpts(t, in, want, &ParseOptions{FixWinding: true})
+}
+
 func TestRingOrientation(t *testing.T) {
 	ccw := []geometry.Point{{X: 0, Y: 0}, {X: 10, Y: 0}, {X: 10, Y: 10}, {X: 0, Y: 10}, {X: 0, Y: 0}}
 	cw := []geometry.Point{{X: 0, Y: 0}, {X: 0, Y: 10}, {X: 10, Y: 10}, {X: 10, Y: 0}, {X: 0, Y: 0}}

--- a/winding_test.go
+++ b/winding_test.go
@@ -1,0 +1,99 @@
+package geojson
+
+import (
+	"testing"
+
+	"github.com/tidwall/geojson/geometry"
+)
+
+// Exterior is given clockwise; a CCW fix should reverse the coords.
+func TestPolygonFixWindingExterior(t *testing.T) {
+	// CW square: (0,0)->(0,10)->(10,10)->(10,0)->(0,0)
+	in := `{"type":"Polygon","coordinates":[[[0,0],[0,10],[10,10],[10,0],[0,0]]]}`
+	want := `{"type":"Polygon","coordinates":[[[0,0],[10,0],[10,10],[0,10],[0,0]]]}`
+	expectJSONOpts(t, in, want, &ParseOptions{FixWinding: true})
+}
+
+// Holes given CCW must be flipped to CW; exterior already CCW stays put.
+func TestPolygonFixWindingHole(t *testing.T) {
+	in := `{"type":"Polygon","coordinates":[` +
+		`[[0,0],[10,0],[10,10],[0,10],[0,0]],` +
+		`[[2,2],[8,2],[8,8],[2,8],[2,2]]]}`
+	want := `{"type":"Polygon","coordinates":[` +
+		`[[0,0],[10,0],[10,10],[0,10],[0,0]],` +
+		`[[2,2],[2,8],[8,8],[8,2],[2,2]]]}`
+	expectJSONOpts(t, in, want, &ParseOptions{FixWinding: true})
+}
+
+// Already-correct rings must not be modified by FixWinding.
+func TestPolygonFixWindingNoop(t *testing.T) {
+	in := `{"type":"Polygon","coordinates":[` +
+		`[[0,0],[10,0],[10,10],[0,10],[0,0]],` +
+		`[[2,2],[2,8],[8,8],[8,2],[2,2]]]}`
+	expectJSONOpts(t, in, in, &ParseOptions{FixWinding: true})
+}
+
+// RequireWinding must reject polygons whose exterior is CW.
+func TestPolygonRequireWindingRejectsExterior(t *testing.T) {
+	in := `{"type":"Polygon","coordinates":[[[0,0],[0,10],[10,10],[10,0],[0,0]]]}`
+	expectJSONOpts(t, in, errCoordinatesInvalid, &ParseOptions{RequireWinding: true})
+}
+
+// RequireWinding must reject polygons whose hole is CCW.
+func TestPolygonRequireWindingRejectsHole(t *testing.T) {
+	in := `{"type":"Polygon","coordinates":[` +
+		`[[0,0],[10,0],[10,10],[0,10],[0,0]],` +
+		`[[2,2],[8,2],[8,8],[2,8],[2,2]]]}`
+	expectJSONOpts(t, in, errCoordinatesInvalid, &ParseOptions{RequireWinding: true})
+}
+
+// RequireWinding accepts correctly wound polygons unchanged.
+func TestPolygonRequireWindingAccepts(t *testing.T) {
+	in := `{"type":"Polygon","coordinates":[` +
+		`[[0,0],[10,0],[10,10],[0,10],[0,0]],` +
+		`[[2,2],[2,8],[8,8],[8,2],[2,2]]]}`
+	expectJSONOpts(t, in, in, &ParseOptions{RequireWinding: true})
+}
+
+// Fixing winding must carry Z coordinates along with the points.
+func TestPolygonFixWindingWithZ(t *testing.T) {
+	in := `{"type":"Polygon","coordinates":[` +
+		`[[0,0,1],[0,10,2],[10,10,3],[10,0,4],[0,0,1]]]}`
+	want := `{"type":"Polygon","coordinates":[` +
+		`[[0,0,1],[10,0,4],[10,10,3],[0,10,2],[0,0,1]]]}`
+	expectJSONOpts(t, in, want, &ParseOptions{FixWinding: true})
+}
+
+// MultiPolygon: mix a CW polygon and a correct polygon; only the bad one flips.
+func TestMultiPolygonFixWinding(t *testing.T) {
+	in := `{"type":"MultiPolygon","coordinates":[` +
+		`[[[0,0],[0,10],[10,10],[10,0],[0,0]]],` +
+		`[[[20,0],[30,0],[30,10],[20,10],[20,0]]]]}`
+	want := `{"type":"MultiPolygon","coordinates":[` +
+		`[[[0,0],[10,0],[10,10],[0,10],[0,0]]],` +
+		`[[[20,0],[30,0],[30,10],[20,10],[20,0]]]]}`
+	expectJSONOpts(t, in, want, &ParseOptions{FixWinding: true})
+}
+
+func TestMultiPolygonRequireWindingRejects(t *testing.T) {
+	in := `{"type":"MultiPolygon","coordinates":[` +
+		`[[[0,0],[10,0],[10,10],[0,10],[0,0]]],` +
+		`[[[20,0],[20,10],[30,10],[30,0],[20,0]]]]}`
+	expectJSONOpts(t, in, errCoordinatesInvalid, &ParseOptions{RequireWinding: true})
+}
+
+func TestRingOrientation(t *testing.T) {
+	ccw := []geometry.Point{{X: 0, Y: 0}, {X: 10, Y: 0}, {X: 10, Y: 10}, {X: 0, Y: 10}, {X: 0, Y: 0}}
+	cw := []geometry.Point{{X: 0, Y: 0}, {X: 0, Y: 10}, {X: 10, Y: 10}, {X: 10, Y: 0}, {X: 0, Y: 0}}
+	degen := []geometry.Point{{X: 0, Y: 0}, {X: 5, Y: 5}, {X: 10, Y: 10}, {X: 0, Y: 0}}
+
+	if got := ringOrientation(ccw); got != 1 {
+		t.Fatalf("ccw: expected 1, got %d", got)
+	}
+	if got := ringOrientation(cw); got != -1 {
+		t.Fatalf("cw: expected -1, got %d", got)
+	}
+	if got := ringOrientation(degen); got != 0 {
+		t.Fatalf("degenerate: expected 0, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds two opt-in `ParseOptions` flags that enforce [RFC 7946 §3.1.6](https://www.rfc-editor.org/rfc/rfc7946#section-3.1.6) polygon ring winding (exterior CCW, holes CW) during parsing of `Polygon` and `MultiPolygon`:

- **`FixWinding`** — silently rewrites non-compliant rings by reversing their points in place. Any z/m values in `extra.values` are reordered to stay aligned with their points, so 3D/4D polygons survive the fix.
- **`RequireWinding`** — returns `errCoordinatesInvalid` when any ring has the wrong winding. Useful for strict validation pipelines.

Rings with zero signed area (degenerate/collinear) are left alone — they carry no orientation to correct.

Both flags default to `false`, so existing callers are unaffected.

## Implementation notes

- Orientation via the shoelace formula on 2D coordinates. Signed area `> 0` → CCW; `< 0` → CW; `== 0` → skip.
- Reversing a closed ring `[P0, P1, ..., Pn, P0]` preserves the first-last equality required by GeoJSON linear rings.
- The fix is applied before the `geometry.Poly` is constructed, so the resulting polygon and its bbox/index are computed from the corrected coordinates.

## Test plan

- [x] `go test ./...` passes
- [x] `gofmt -l .` / `go vet ./...` clean
- [x] New tests in `winding_test.go` cover:
  - Fix flips CW exterior to CCW
  - Fix flips CCW hole to CW
  - Fix is a no-op when rings are already compliant
  - Fix preserves z coordinates
  - Require rejects CW exterior / CCW hole and accepts compliant input
  - MultiPolygon fix and reject paths
  - `ringOrientation` unit tests for CCW / CW / degenerate rings